### PR TITLE
LPS-102340 Misleading syntax error message testing push notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'maven-publish'
 apply from: 'bintray.gradle'
 
 group 'com.liferay.mobile'
-version '0.3.0'
+version '0.4.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/src/main/java/com/liferay/mobile/fcm/Sender.java
+++ b/src/main/java/com/liferay/mobile/fcm/Sender.java
@@ -14,6 +14,7 @@
 
 package com.liferay.mobile.fcm;
 
+import com.liferay.mobile.fcm.exception.UnsuccessfulResponse;
 import com.liferay.mobile.fcm.json.Json;
 
 import java.io.Reader;
@@ -41,6 +42,10 @@ public class Sender {
 	public Status send(Message message) throws Exception {
 		Request request = createRequest(message);
 		Response response = client.newCall(request).execute();
+
+		if (response.code() != 200) {
+			throw new UnsuccessfulResponse(response.code(), response.message());
+		}
 
 		Reader body = response.body().charStream();
 		Status status = statusFactory.createStatus(message, body);

--- a/src/main/java/com/liferay/mobile/fcm/exception/UnsuccessfulResponse.java
+++ b/src/main/java/com/liferay/mobile/fcm/exception/UnsuccessfulResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.mobile.fcm.exception;
+
+/**
+ * @author Ricardo Couso
+ */
+public class UnsuccessfulResponse extends Exception {
+
+    public UnsuccessfulResponse(int code, String message) {
+        super("Unsuccessful response: (" + code + ") " + message);
+    }
+
+}


### PR DESCRIPTION
Hi @brunofarache,

If the API Key for Firebase Push Notifications Sender isn't valid, any test push notification will fail due to an apparent syntax error. In actuality, the response will have a 401 status and the gson parser won't be parsing actual json. (See [LPS-102340](https://issues.liferay.com/browse/LPS-102340).)

I wasn't sure if there was a particular task to update the version. 

Please let me know if you have any questions or comments.